### PR TITLE
Added bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,67 @@
+---
+name: Bug report
+about: Let us know about an unexpected error, a crash, or an incorrect behavior.
+
+---
+
+### Version
+<!---
+Please provide versions of your Docker and Go.
+-->
+
+```
+...
+```
+
+
+### Debug or Crash Output
+<!--
+Was there any output or error message? Feel free to share a screenshot or anything you think will be helpful.
+-->
+
+```
+...
+```
+
+
+### Expected Behavior
+<!--
+What should have happened?
+-->
+
+```
+...
+```
+
+### Actual Behavior
+<!--
+What actually happened?
+-->
+
+```
+...
+```
+
+
+### Steps to Reproduce
+<!--
+Please list the full steps required to reproduce the issue.
+1. details regarding my step 1
+2. details regarding my step 2
+-->
+
+```
+...
+```
+
+
+### Additional Context
+<!--
+Please provide any additional context regarding the bug.
+-->
+
+
+### References
+<!--
+Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature request
+about: Suggest a new feature or other enhancement.
+
+---
+
+### Motivation Behind Feature
+<!---
+Please provide reasoning why this feature should be implemented? What problem does it solve?
+-->
+
+```
+...
+```
+
+
+### Attempted Solutions
+<!--
+Please describe alternatives or workarounds you are currently using.
+-->
+
+```
+...
+```
+
+
+### Proposal
+<!--
+Please describe your feature request in detail. Include examples, screenshots or additional information.
+-->
+
+```
+...
+```
+
+### Additional Context
+<!--
+Please provide any additional context regarding the feature request.
+-->


### PR DESCRIPTION
The following PR adds the bug report and feature request issue templates to the repository. This is in reference to issue https://github.com/mralanlee/wm_analytics/issues/20. I have used inspiration from the hashicorp/terraform example as well as my previous projects. However, I'm not sure how to test this before merging it to the default branch.